### PR TITLE
Fixed print statements in test scripts to be comp with py35

### DIFF
--- a/test/scripts/test_checkm.py
+++ b/test/scripts/test_checkm.py
@@ -7,7 +7,7 @@ import os
 import errno
 
 if len(sys.argv) == 1:
-	print "Please provide a filename"
+	print("Please provide a filename")
 	sys.exit()
 
 # output file
@@ -36,9 +36,9 @@ except OSError as o:
 	f.close()
 	sys.exit()
 except:
- 	f.write('Unexpected error: unable to run checkM' + '\n')
-	f.close()
-	sys.exit()
+    f.write('Unexpected error: unable to run checkM' + '\n')
+    f.close()
+    sys.exit()
 
 # if we're still here, check error and print
 if error == '':

--- a/test/scripts/test_phylophlan.py
+++ b/test/scripts/test_phylophlan.py
@@ -7,14 +7,14 @@ import os
 import errno
 
 if len(sys.argv) == 1:
-	print "Please provide a filename"
+	print("Please provide a filename")
 	sys.exit()
 
 # phylophlan dir
 phydir = sys.argv[1]
 
 if not os.path.exists(phydir) or not os.path.isdir(phydir):
-	print phydir + " does not exist or isn't a directory"
+	print(phydir + " does not exist or isn't a directory")
 	sys.exit()	
 
 # output file
@@ -69,9 +69,9 @@ except OSError as o:
 	f.close()
 	sys.exit()
 except:
- 	f.write('Unexpected error: unable to run phylophlan' + '\n')
-	f.close()
-	sys.exit()
+    f.write('Unexpected error: unable to run phylophlan' + '\n')
+    f.close()
+    sys.exit()
 
 # if we're still here, check error and print
 if error == '':


### PR DESCRIPTION
I noticed that if running `snakemake -s MAGpy test` in a python 3.5 environment two of the test functions produced errors related to print statements. I went ahead and fixed those two test scripts to be compatible with python 3.5 and the tests appear to work now. 