### PR TITLE
Diamond summary report fix to avoid argument list length issues

### DIFF
--- a/MAGpy
+++ b/MAGpy
@@ -62,7 +62,11 @@ rule diamond_report:
 rule diamond_bin_summary:
         input: expand("diamond_report/bin.{sample}.tsv", sample=IDS)
         output: "diamond_bin_report.tsv"
-        shell: "echo -e 'name\tnprots\tnhits\tnfull\tgenus\tngenus\tspecies\tnspecies\tavgpid' >> {output} && cat {input} >> {output}"
+	shell:
+		"""
+		echo -e 'name\tnprots\tnhits\tnfull\tgenus\tngenus\tspecies\tnspecies\tavgpid' >> {output}
+            	find diamond_report/ -name "bin*.tsv" | xargs -I {{}} cat {{}} >> {output}  
+		"""
 
 rule diamond_bin_summary_plus:
         input: "diamond_bin_report.tsv"


### PR DESCRIPTION
This is a potential fix in reference to #11 . 

Instead of using cat to print the output of all the inputs this uses find and xargs to bypass the need to  print all the files to the command line. It works with my large dataset as well as the snakemake test provided (but I am not sure that this is tested by the designed tests). 