### PR TITLE
Sourcing directive bugfix and minor updates

### DIFF
--- a/MAGpy
+++ b/MAGpy
@@ -1,5 +1,8 @@
 shell.executable("/bin/bash")
 
+from snakemake.utils import min_version
+min_version("5.0")
+
 import os
 
 configfile: "config.json"

--- a/MAGpy
+++ b/MAGpy
@@ -183,8 +183,11 @@ rule test:
 rule test_checkm:
 	output: "test/outputs/checkm.txt"
 	conda: "envs/checkm.yaml"
+	params:
+		checkmdata=config["checkm_dataroot"
 	shell:
 		'''
+        checkm data setRoot {params.checkmdata}
 		test/scripts/test_checkm.py {output}	
 		'''	
 

--- a/MAGpy
+++ b/MAGpy
@@ -184,10 +184,11 @@ rule test_checkm:
 	output: "test/outputs/checkm.txt"
 	conda: "envs/checkm.yaml"
 	params:
-		checkmdata=config["checkm_dataroot"
+		cdr=config["checkm_dataroot"]
 	shell:
 		'''
-        checkm data setRoot {params.checkmdata}
+		checkm_db={params.cdr}
+		echo ${{checkm_db}} | checkm data setRoot ${{checkm_db}}
 		test/scripts/test_checkm.py {output}	
 		'''	
 

--- a/MAGpy
+++ b/MAGpy
@@ -1,5 +1,4 @@
 shell.executable("/bin/bash")
-shell.prefix("source $HOME/.bashrc; ")
 
 import os
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd MAGpy
 Run the tests:
 
 ```sh
-snakemake --use-conda -s MAGpy test
+snakemake --use-conda -s MAGpy --cores 1 test
 ```
 
 Test outputs will be in ```test/outputs``` and you should have an ```error_log``` file in your current working directory.
@@ -61,10 +61,10 @@ Edit the config.json and point to the databases and directories created during t
 
 In this directory, put all of your genomes into the mags folder, one file per genome, with a .fa file extension
 
-Then to run in basic (linear, non-cluster) mode:
+Then to run in basic (linear, non-cluster) mode, where `$N` is the number of parallel threads you want to use:
 
 ```
-snakemake --use-conda -s MAGpy
+snakemake --use-conda -s MAGpy --cores $N
 ```
 
 Outputs will be placed into the *current working directory*, so make sure you have write access.

--- a/install.md
+++ b/install.md
@@ -7,7 +7,7 @@
 ### 1 Update ubuntu
 ```sh
 sudo apt-get update
-sudo apt install gcc g++ make
+sudo apt install gcc g++ make wget git
 ```
 
 ### 2 install usearch 
@@ -33,7 +33,7 @@ sh Miniconda3-latest-Linux-x86_64.sh
 # review license
 # accept license
 # accept or change home location
-# yes to placing it in your path
+# yes to running conda init to place it in your path
 
 # source .bashrc
 source $HOME/.bashrc
@@ -52,7 +52,7 @@ git clone https://github.com/WatsonLab/MAGpy.git
 conda env create -f MAGpy/envs/install.yaml
 
 # activate it
-source activate magpy_install
+conda activate magpy_install
 ```
 
 ### 6 download data and build indices
@@ -124,8 +124,6 @@ source activate basic2
 
 /usr/bin/env perl -MCPAN -e 'install Color::Mix'
 # answer yes to automatic config
-# answer a to all
-# answer n to XML additional tools
 ```
 
 


### PR DESCRIPTION
There was a bug caused by the `.bashrc` source directive at the
start of the snakefile

On a clean Ubuntu 18.04 container envs were being activated for each
rule but then seemingly deactivated when snakemake started to execute
the shell component.

This caused the python2.7 reliant phylophlan and checkm test scripts to
error.

For example, output from adding `conda env list` to the `test_checkm`
rule shows the correct activation before the shell but the wrong activated
environment (shown by asterisk) in the shell instance for the rule:

```
activating conda environment: /home/root/MAGpy/.snakemake/conda/377a289b
           /home/root/MAGpy/.snakemake/conda/377a289b
           /home/root/MAGpy/.snakemake/conda/8a832417
           base
        *  /root/miniconda3
```

I think the directive means snakemake (v5.11.2) was sourcing the
`.bashrc` when starting the shell for each rule and resetting to the
base environment before executing the rule script commands.

Without that directive the code everything seems to run fine for the
tests and full pipeline when tested with snakemake version >5

Otherwise, it was a few trivial updates to documentation, and adding a command to set the checkm dataroot as it was waiting for input and hanging on the `test_checkm` rule.